### PR TITLE
Removed database credentials into environment variables

### DIFF
--- a/core/database/connect.php
+++ b/core/database/connect.php
@@ -6,6 +6,6 @@ mysql_select_db('webdevu1_useru') or die($connect_error);*/
 
 <?php
 $connect_error = "Site under maintenance.";
-mysql_connect('localhost', 'webleyson', 'supplier', '') or die($connect_error);
-mysql_select_db('useru') or die($connect_error);
+mysql_connect(getenv("USERU_DB_HOST"), getenv("USERU_DB_USER"), getenv("USERU_DB_PASSWD"), '') or die($connect_error);
+mysql_select_db(getenv("USERU_DB_NAME")) or die($connect_error);
 ?>

--- a/core/database/connect.php
+++ b/core/database/connect.php
@@ -2,9 +2,7 @@
 /*$connect_error = "Site under maintenance.";
 mysql_connect('localhost', 'webdevu1_webley', 'supplier123', '') or die($connect_error);
 mysql_select_db('webdevu1_useru') or die($connect_error);*/
-?>
 
-<?php
 $connect_error = "Site under maintenance.";
 mysql_connect(getenv("USERU_DB_HOST"), getenv("USERU_DB_USER"), getenv("USERU_DB_PASSWD"), '') or die($connect_error);
 mysql_select_db(getenv("USERU_DB_NAME")) or die($connect_error);


### PR DESCRIPTION
**_What**_

Removes the database connection parameters from source code and puts them into environment variables

**_How to test**_

Create 4 environment variables:

``` shell
USERU_DB_HOST=127.0.0.1
USERU_DB_USER=<username>
USERU_DB_PASSWD=<password>
USERU_DB_NAME=useru
```

Run the built-in PHP webserver using

`php -S localhost:9000`

Visit the page and verify that the application can connect to the database
